### PR TITLE
docs: add target persona structure and overview (7-user summary)

### DIFF
--- a/docs/target-persona.md
+++ b/docs/target-persona.md
@@ -1,0 +1,37 @@
+# Target Personas
+
+This document describes the key categories of users of our file storage platform.  
+The goal is to identify our key users, understand their pain points and goals, and align product and architectural decisions accordingly.
+
+### Each persona contains:
+
+- The role and context of use of the platform
+- Key pains and constraints
+- The goals and challenges they want to solve
+- How our product helps them achieve those goals
+
+### This allows us to:
+
+- Justify product and technical decisions
+- Shape MVP chips for real-world scenarios
+- Speak the language of users in documentation, CLI, GitHub READMEs
+- Build understandable demo scenarios
+- Use the project as an argument in open-source
+
+---
+
+## Overview of all personas
+
+| Persona | Role | Core Pain | Goal | Relevant Features |
+|--------|------|------------------------------|-----------------------------|----------------------------|
+| Small SaaS CTO | Product and tech lead | Difficult and risky IAM integration | Deploy secure file storage in 15 minutes without complexity | Built-in RBAC, JWT, audit logs, CLI |
+| DevOps Engineer | Automation / CI/CD | No CLI or API for automation | Integrate file storage into pipelines and scripts | fsctl, REST/gRPC, audit API |
+| Security Engineer | Access control and threat monitoring | No revoke, no TTL, no alerts | Monitor usage and respond to threats in real time | TTL links, revoke, ML-based anomaly detection |
+| Privacy Officer (GDPR) | Legal / compliance | No consent tracking or access logs | Ensure traceable, compliant access history | Consent API, full audit logs, GDPR compliance |
+| SRE / Observability Engineer | Monitoring / SLAs | No metrics, tracing, or visibility | Detect issues and understand impact quickly | Prometheus, OpenTelemetry, Grafana |
+| Enterprise Integrator | B2B / corporate IT | Needs LDAP, flexible access policies | Plug file storage into enterprise auth systems | Keycloak, LDAP, policy engine |
+| Internal Platform Developer | Backend / platform engineering | Needs fast secure integration for internal tools | Quickly embed file storage with built-in policies | API, CLI, preconfigured IAM and defaults |
+
+---
+
+


### PR DESCRIPTION
### Summary

Created `docs/target-persona.md` to formalize key user types and their relationship to platform goals.

---

### Issue

- Product and technical solutions often drift without a clear understanding of users.
- OSS documentation lacks structured personas aligned to real-world usage scenarios.

---

### Solution

- Described 7 core user personas with their roles, pain points, goals, and platform capabilities.
- Introduced a single overview table for review and planning.
- Created structure for detailed persona profiles (for future completion).

---

### Personas covered

- Small SaaS CTO  
- DevOps Engineer  
- Security Engineer  
- Privacy Specialist (GDPR)  
- SRE / Observability Engineer  
- Enterprise Integrator  
- Backend Platform Developer

---

### Impact

- Clarifies for engineers and contributors who we are building the product for and why.
- Provides a backbone for MVP prioritization, demo flows, and OSS clarity.
- Improves project positioning for product reviews, interviews, and visa cases.

---

### Checklist

- [x] File created: `docs/target-persona.md`
- [x] Table with all 7 personas
- [x] Clear description of problem/goal per persona
- [ ] Add per-person deep profiles (e.g., SaaS CTO)
- [ ] Link personas to demo scenarios
